### PR TITLE
Add script functionality

### DIFF
--- a/podcastAnalyzer.py
+++ b/podcastAnalyzer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import math
+import sys
 import urllib2
 from lxml import etree
 
@@ -13,3 +14,15 @@ def parse_url(url):
         print episode.find('title').text
         print episode.find('itunes:duration', parsed_xml.nsmap).text
         print episode.find('pubDate').text
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print "Usage: ./podcastAnalyzer.py \"URL\""
+        sys.exit(1)
+
+    url = sys.argv[1]
+    if url[0] != '"' or url[-1:] != '"':
+        print "Error: The URL must be surrounded by quotation marks."
+        sys.exit(1)
+
+    parse_url(url)

--- a/podcastAnalyzer.py
+++ b/podcastAnalyzer.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import math
 import urllib2
 from lxml import etree


### PR DESCRIPTION
This pull request adds a shebang, argument parsing, and execute permissions to the Python program.

The script can now be executed like so:
```
./podcastAnalyzer.py "https://www.google.ca"
```
(though this example will not work properly since Google's home page is likely to have any podcast data).