### PR TITLE
Add user agent and tidy up parsing of episodes

### DIFF
--- a/podcastAnalyzer.py
+++ b/podcastAnalyzer.py
@@ -29,7 +29,9 @@ def calc_podcast_rate(episode_list):
     return rate_array
 
 def parse_url(url):
-    parsed_xml = etree.fromstring(urllib2.urlopen(url).read())
+    user_agent = 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.0.7) Gecko/2009021910 Firefox/3.0.7'
+    request = urllib2.Request(url, headers={'User-Agent':user_agent})
+    parsed_xml = etree.fromstring(urllib2.urlopen(request).read())
 
     if(parsed_xml.tag != "rss" and parsed_xml[0].tag != "channel"):
         print "Incorrect XML format."

--- a/podcastAnalyzer.py
+++ b/podcastAnalyzer.py
@@ -21,11 +21,13 @@ class Episode(object):
 def calc_podcast_rate(episode_list):
     rate_array = []
     end_date = datetime.today()
+    SECONDS_IN_DAY = 86400.0
     for episode in episode_list:
         period = end_date - episode.pubDate
-        rate = episode.duration/period.days
-        rate_array.append(rate * 7)
-        end_date = episode.pubDate
+        if(period.total_seconds() > 0):
+            rate = episode.duration/(period.total_seconds()/SECONDS_IN_DAY)
+            rate_array.append(rate * 7)
+            end_date = episode.pubDate
     return rate_array
 
 def parse_url(url):

--- a/podcastAnalyzer.py
+++ b/podcastAnalyzer.py
@@ -31,7 +31,7 @@ def calc_podcast_rate(episode_list):
     return rate_array
 
 def parse_url(url):
-    user_agent = 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.0.7) Gecko/2009021910 Firefox/3.0.7'
+    user_agent = 'podcast-parakeet/0.1.0 (+https://github.com/CtrlShiftGo/podcast-parakeet)'
     request = urllib2.Request(url, headers={'User-Agent':user_agent})
     parsed_xml = etree.fromstring(urllib2.urlopen(request).read())
 


### PR DESCRIPTION
## Synopsis
* Add user agent 'podcast-parakeet' with link back to github page
* Fix bug in parsing podcasts which upload on the same day
* Fix bug in parsing podcasts with episodes uploaded at the same second

The script now identifies itself using a user agent. This will also fix a bug which prevented the parsing of podcasts where the duration between episodes can reach zero seconds.

The script will both refuse to parse adjacent episodes which have identical timestamps, instead moving on to the next one and ignoring that particular one. Furthermore this pull request will modify the script to parse durations as a number of seconds between episodes rather than the number of days, allowing the parsing of podcasts which upload multiple times per day.